### PR TITLE
Allows prompt string to be customized

### DIFF
--- a/lib/prompt.js
+++ b/lib/prompt.js
@@ -62,7 +62,7 @@ prompt.start = function (options) {
   options = options        || {};
   stdin   = options.stdin  || process.openStdin();
   stdout  = options.stdout || process.stdout;
-
+  prompt.promptString = options.promptString;
   //
   // By default: Remeber the last `10` prompt property /
   // answer pairs and don't allow empty responses globally.
@@ -183,7 +183,9 @@ prompt.get = function (msg, callback) {
 //
 prompt.getInput = function (prop, callback) {
   var name   = prop.message || prop.name || prop,
-      raw    = ['prompt', ': ' + name.grey, ': '.grey],
+      raw    = prompt.promptString 
+               ? [prompt.promptString.replace('%msg%', name)] 
+               : ['prompt', ': ' + name.grey, ': '.grey],
       read   = prop.hidden ? prompt.readLineHidden : prompt.readLine,
       length, msg;
 


### PR DESCRIPTION
Currently, the 'prompt string' always says 'prompt:', and then the property message/name in grey.  This patch allows that string to be customized.  

This patch implements `prompt.promptString`, which consists of two parts joined together: the base prompt message (to replace 'prompt:') and a replace string, `%msg%`, which gets replaced with the message or name of the individual property being prompted for.  

I have made this a pull request pending approval of the specific implementation.  
