### PR TITLE
Issue #3 also affects non-hidden fields, adding test case for it

### DIFF
--- a/test/helpers.js
+++ b/test/helpers.js
@@ -56,6 +56,10 @@ helpers.properties = {
     validator: /^[\w|\-]+$/,
     warning: 'Username can only be letters, numbers, and dashes'
   },
+  notblank: {
+    name: 'notblank',
+    empty: false
+  },
   password: {
     name: 'password',
     hidden: true,

--- a/test/prompt-test.js
+++ b/test/prompt-test.js
@@ -73,6 +73,31 @@ vows.describe('prompt').addBatch({
           assert.isTrue(this.msg.indexOf('test input') !== -1);
         }
       },
+      "with any field that is not supposed to be empty": {
+        "and we don't provide any input": {
+          topic: function () {
+            var that = this;
+            helpers.stdout.once('data', function (msg) {
+              that.msg = msg;
+            });
+
+            helpers.stderr.once('data', function (msg) {
+              that.errmsg = msg;
+            });
+
+            prompt.getInput(helpers.properties.notblank, function () {});
+            prompt.once('invalid', this.callback.bind(null, null))
+            helpers.stdin.write('\n');
+          },
+
+          "should prompt with an error": function (ign, prop, input) {
+            assert.isObject(prop);
+            assert.equal(input, '');
+            assert.isTrue(this.errmsg.indexOf('Invalid input') !== -1);
+            assert.isTrue(this.msg.indexOf('notblank') !== -1);
+          }
+        }
+      },
       "with a hidden field that is not supposed to be empty": {
         "and we provide valid input": {
           topic: function () {


### PR DESCRIPTION
Although this is already fixed, I added a new test case to reflect a non-hidden field.

Bug #3 actually affected all inputs rather than just hidden ones.
Previously empty fields required a validator to function properly.
This commit adds a test case verifying that even the non-hidden fields function properly when they are empty and are given no input.
