### PR TITLE
Remove `flush` usage

### DIFF
--- a/lib/prompt.js
+++ b/lib/prompt.js
@@ -394,6 +394,7 @@ prompt.readLineHidden = function (callback) {
           stdin.removeListener('error', callback);
           value = value.trim();
           stdout.write('\n');
+          stdout.flush && stdout.flush();
           prompt.pause();
           return callback(null, value);
         case '\x7f': case'\x08':


### PR DESCRIPTION
Using `flush` is no longer valid in v0.5.
