### PR TITLE
the SIGINT command breaks the jitsu CLI interface which relies on prompt

### DIFF
--- a/lib/prompt.js
+++ b/lib/prompt.js
@@ -74,10 +74,13 @@ prompt.start = function (options) {
   prompt.message    = options.message    || prompt.message;
   prompt.delimiter  = options.delimiter  || prompt.delimiter;
 
-  process.on('SIGINT', function () {
-    stdout.write('\n');
-    process.exit(1);
-  });
+  if (process.platform !== 'win32') {
+    // windows falls apart trying to deal with SIGINT
+    process.on('SIGINT', function () {
+      stdout.write('\n');
+      process.exit(1);
+    });   
+  }
 
   prompt.emit('start');
   prompt.started = true;


### PR DESCRIPTION
Wrapping it with a if not windows check makes jitsu work on windows7 with 0.6.4.

Looks "safe" to me.

http://nodejs.org/docs/v0.6.4/api/process.html#process.platform

I confirm that node 0.6.4 on windows out puts 'win32' for `process.platform`
