### PR TITLE
adding prompt.confirm method

### DIFF
--- a/lib/prompt.js
+++ b/lib/prompt.js
@@ -183,6 +183,46 @@ prompt.get = function (msg, callback) {
 };
 
 //
+// ### function confirm (msg, callback)
+// #### @msg {Array|Object|string} set of message to confirm
+// #### @callback {function} Continuation to pass control to when complete.
+// Confirms a single or series of messages by prompting the user for a Y/N response.
+// Returns `true` if ALL messages are answered in the affirmative, otherwise `false`
+//
+// `msg` can be a string, or object (or array of strings/objects).
+// An object may have the following properties:
+//  {
+//    message : 'yes/no' // message to prompt user
+//    validator : /^[yntf]{1}/i // optional - regex defining acceptable responses
+//    yes : /^[yt]{1}/i // optional - regex defining `affirmative` responses
+//    warning : 'yes/no' // optional - message to display for invalid responses
+//  }
+//
+prompt.confirm = function (msg, callback) {
+  var vars = !Array.isArray(msg) ? [msg] : msg,
+      RX_Y = /^[yt]{1}/i,
+      RX_YN = /^[yntf]{1}/i;
+
+  function confirm(target, next) {
+    var yes = target.yes || RX_Y,
+      options = {
+        message : typeof target === 'string' ? target : target.message||'yes/no',
+        validator : target.validator || RX_YN,
+        name : 'confirm',
+        warning : target.warning || 'yes/no'
+      };
+
+    prompt.get(options, function (err, result) {
+      next(err ? false : yes.test(result[options.name]));
+    });
+  }
+  async.rejectSeries(vars, confirm, function(result) {
+    callback(null, result.length===0);
+  });
+
+};
+
+//
 // ### function getInput (msg, validator, callback)
 // #### @msg {Object|string} Variable to get input for.
 // #### @callback {function} Continuation to pass control to when complete.

--- a/test/prompt-test.js
+++ b/test/prompt-test.js
@@ -385,6 +385,248 @@ vows.describe('prompt').addBatch({
       }
     }
   }
+}).addBatch({
+  "when using prompt": {
+    topic: function () {
+      //
+      // Reset the prompt for mock testing
+      //
+      prompt.started = false;
+      prompt.start({
+        stdin: helpers.stdin,
+        stdout: helpers.stdout
+      });
+
+      return null;
+    },
+    "the confirm() method": {
+      "with a string message" : {
+        "responding with Y" : {
+          topic: function () {
+            prompt.confirm('test', this.callback);
+            helpers.stdin.write('Y\n');
+          },
+          "should respond with true" : function(err, result) {
+            assert.isNull(err);
+            assert.isTrue(result);
+          }
+        },
+        "responding with N" : {
+          topic: function () {
+            prompt.confirm('test', this.callback);
+            helpers.stdin.write('N\n');
+          },
+          "should respond with false" : function(err, result) {
+            assert.isNull(err);
+            assert.isFalse(result);
+          }
+        },
+        "responding with YES" : {
+          topic: function () {
+            prompt.confirm('test', this.callback);
+            helpers.stdin.write('YES\n');
+          },
+          "should respond with true" : function(err, result) {
+            assert.isNull(err);
+            assert.isTrue(result);
+          }
+        },
+        "responding with NO" : {
+          topic: function () {
+            prompt.confirm('test', this.callback);
+            helpers.stdin.write('NO\n');
+          },
+          "should respond with false" : function(err, result) {
+            assert.isNull(err);
+            assert.isFalse(result);
+          }
+        },
+        "responding with T" : {
+          topic: function () {
+            prompt.confirm('test', this.callback);
+            helpers.stdin.write('T\n');
+          },
+          "should respond with true" : function(err, result) {
+            assert.isNull(err);
+            assert.isTrue(result);
+          }
+        },
+        "responding with F" : {
+          topic: function () {
+            prompt.confirm('test', this.callback);
+            helpers.stdin.write('F\n');
+          },
+          "should respond with false" : function(err, result) {
+            assert.isNull(err);
+            assert.isFalse(result);
+          }
+        },
+        "responding with TRUE" : {
+          topic: function () {
+            prompt.confirm('test', this.callback);
+            helpers.stdin.write('TRUE\n');
+          },
+          "should respond with true" : function(err, result) {
+            assert.isNull(err);
+            assert.isTrue(result);
+          }
+        },
+        "responding with FALSE" : {
+          topic: function () {
+            prompt.confirm('test', this.callback);
+            helpers.stdin.write('FALSE\n');
+          },
+          "should respond with false" : function(err, result) {
+            assert.isNull(err);
+            assert.isFalse(result);
+          }
+        }
+      },
+      "with an object" : {
+        "and message set" : {
+          topic: function() {
+            prompt.confirm({message:'a custom message'}, this.callback);
+            helpers.stdin.write('Y\n');
+          },
+          "should respond with true" : function(err, result) {
+            assert.isNull(err);
+            assert.isTrue(result);
+          }
+        },
+        "and they forgot the message" : {
+          topic: function() {
+            prompt.confirm({}, this.callback);
+            helpers.stdin.write('Y\n');
+          },
+          "should respond with true" : function(err, result) {
+            assert.isNull(err);
+            assert.isTrue(result);
+          }
+        },
+        "and custom validators" : {
+          "responding node" : {
+            topic : function() {
+              prompt.confirm({
+                message : 'node or jitsu?',
+                validator : /^(node|jitsu)/i,
+                yes : /^node/i
+              }, this.callback);
+              helpers.stdin.write('node\n');
+            },
+            "should respond with true" : function(err, result) {
+              assert.isNull(err);
+              assert.isTrue(result);
+            }
+          },
+          "responding jitsu" : {
+            topic : function() {
+              prompt.confirm({
+                message : 'node or jitsu?',
+                validator : /^(node|jitsu)/i,
+                yes : /^node/i
+              }, this.callback);
+              helpers.stdin.write('jitsu\n');
+            },
+            "should respond with false" : function(err, result) {
+              assert.isNull(err);
+              assert.isFalse(result);
+            }
+          }
+        }
+      }
+    },
+    "with multiple strings" : {
+      "responding with yesses" : {
+        topic : function() {
+          prompt.confirm(["test", "test2", "test3"], this.callback);
+          helpers.stdin.write('Y\n');
+          helpers.stdin.write('y\n');
+          helpers.stdin.write('YES\n');
+        },
+        "should respond with true" : function(err, result) {
+          assert.isNull(err);
+          assert.isTrue(result);
+        }
+      },
+      "responding with one no" : {
+        topic : function() {
+          prompt.confirm(["test", "test2", "test3"], this.callback);
+          helpers.stdin.write('Y\n');
+          helpers.stdin.write('N\n');
+          helpers.stdin.write('YES\n');
+        },
+        "should respond with false" : function(err, result) {
+          assert.isNull(err);
+          assert.isFalse(result);
+        }
+      },
+      "responding with all noes" : {
+        topic : function() {
+          prompt.confirm(["test", "test2", "test3"], this.callback);
+          helpers.stdin.write('n\n');
+          helpers.stdin.write('NO\n');
+          helpers.stdin.write('N\n');
+        },
+        "should respond with false" : function(err, result) {
+          assert.isNull(err);
+          assert.isFalse(result);
+        }
+      }
+    },
+    "with multiple objects" : {
+      "responding with yesses" : {
+        topic : function() {
+          prompt.confirm(
+            [
+              {message:"test"},
+              {message:"test2"}
+            ],
+            this.callback
+          );
+          helpers.stdin.write('y\n');
+          helpers.stdin.write('y\n');
+        },
+        "should respond with true" : function(err, result) {
+          assert.isNull(err);
+          assert.isTrue(result);
+        }
+      },
+      "responding with noes" : {
+        topic : function() {
+          prompt.confirm(
+            [
+              {message:"test"},
+              {message:"test2"}
+            ],
+            this.callback
+          );
+          helpers.stdin.write('n\n');
+          helpers.stdin.write('n\n');
+        },
+        "should respond with false" : function(err, result) {
+          assert.isNull(err);
+          assert.isFalse(result);
+        }
+      },
+      "responding with yes and no" : {
+        topic : function() {
+          prompt.confirm(
+            [
+              {message:"test"},
+              {message:"test2"}
+            ],
+            this.callback
+          );
+          helpers.stdin.write('n\n');
+          helpers.stdin.write('y\n');
+        },
+        "should respond with false" : function(err, result) {
+          assert.isNull(err);
+          assert.isFalse(result);
+        }
+      }
+    }
+  }
 }).export(module);
 
 


### PR DESCRIPTION
I added a `confirm` method to prompt that prompts for a Y/N style response to one or more messages.  I tried to keep it similar to other pieces of the library in allowing customization of certain properties.  I may have gone overboard on the tests and comments, so feel free to scale those back if needed.
