### PR TITLE
Remove colors dependency.

### DIFF
--- a/lib/prompt.js
+++ b/lib/prompt.js
@@ -9,7 +9,6 @@ var events = require('events'),
     utile = require('utile'),
     async = utile.async,
     capitalize = utile.inflect.capitalize,
-    colors = require('colors'),
     winston = require('winston'),
     validate = require('revalidator').validate,
     tty = require('tty');
@@ -389,7 +388,7 @@ prompt.getInput = function (prop, callback) {
 
   name = prop.description || schema.description || propName;
   read = (schema.hidden ? prompt.readLineHidden : prompt.readLine);
-  raw = [prompt.message, delim + name.grey, delim.grey];
+  raw = [prompt.message, delim + name, delim];
 
   defaultLine = schema.default;
   prop = {
@@ -469,7 +468,7 @@ prompt.getInput = function (prop, callback) {
     }
 
     if (!valid.valid) {
-      logger.error('Invalid input for ' + name.grey);
+      logger.error('Invalid input for ' + name);
       if (prop.schema.message) {
         logger.error(prop.schema.message);
       }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
   },
   "dependencies": {
     "utile": "0.1.x",
-    "colors": "0.x.x",
     "pkginfo": "0.x.x",
     "winston": "0.6.x",
     "revalidator": "0.1.x"


### PR DESCRIPTION
A module dependency should not be messing with the built-in prototypes.
The user should explicitly require('colors') in their own scripts if
they want color properties attached to the String prototype.

See also an alternative "no-default-colors"
