### PR TITLE
Add colors options to prompt.start

### DIFF
--- a/lib/prompt.js
+++ b/lib/prompt.js
@@ -30,6 +30,7 @@ prompt.paused     = false;
 prompt.allowEmpty = false;
 prompt.message    = 'prompt';
 prompt.delimiter  = ': ';
+prompt.colors     = false;
 
 //
 // Create an empty object for the properties
@@ -69,6 +70,7 @@ prompt.start = function (options) {
   prompt.allowEmpty = options.allowEmpty || false;
   prompt.message    = options.message    || prompt.message;
   prompt.delimiter  = options.delimiter  || prompt.delimiter;
+  prompt.colors     = options.colors     || prompt.colors;
 
   if (process.platform !== 'win32') {
     // windows falls apart trying to deal with SIGINT
@@ -389,7 +391,12 @@ prompt.getInput = function (prop, callback) {
 
   name = prop.description || schema.description || propName;
   read = (schema.hidden ? prompt.readLineHidden : prompt.readLine);
-  raw = [prompt.message, delim + name.grey, delim.grey];
+
+  if (prompt.colors) {
+    raw = [prompt.message, delim + name.grey, delim.grey];
+  } else {
+    raw = [prompt.message, delim + name, delim];
+  }
 
   defaultLine = schema.default;
   prop = {
@@ -469,7 +476,11 @@ prompt.getInput = function (prop, callback) {
     }
 
     if (!valid.valid) {
-      logger.error('Invalid input for ' + name.grey);
+      if (prompt.colors) {
+        logger.error('Invalid input for ' + name.grey);
+      } else {
+        logger.error('Invalid input for ' + name);
+      }
       if (prop.schema.message) {
         logger.error(prop.schema.message);
       }


### PR DESCRIPTION
This option defaults to `false`, and enables/diables a default set of
colors for the prompts and log messages.

Previously we were forcing grey colors upon users, which was somewhat
opinionated.

Signed-off-by: Tim Smart tim@fostle.com
