### PR TITLE
Validate that default value is string or numeric

### DIFF
--- a/lib/prompt.js
+++ b/lib/prompt.js
@@ -390,6 +390,9 @@ prompt.getInput = function (prop, callback) {
 
   schema = convert(schema);
   defaultLine = schema.default;
+  if (typeof defaultLine !== 'string'){
+    defaultLine = defaultLine.toString ? defaultLine.toString() : null;
+  }
   name = prop.description || schema.description || propName;
   raw = prompt.colors
     ? [prompt.message, delim + name.grey, delim.grey]


### PR DESCRIPTION
Right now there is an implicit\* validation done after the read (https://github.com/flatiron/prompt/blob/master/lib/prompt.js#L463), but I think it might be helpful to do an explicit validation beforehand.
- implicit only because it's not strictly testing the default value, unless the default is being returned
