### PR TITLE
Fixes wrong version number for read dependency in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "pkginfo": "0.x.x",
-    "read": "1.0.x",
+    "read": "0.1.x",
     "revalidator": "0.1.x",
     "utile": "0.1.x",
     "winston": "0.6.x"


### PR DESCRIPTION
This will make your module installable via npm again.
