### PR TITLE
[fix] When performing validation, gracefully handle the case of numeric inputs with parseFloat

### DIFF
--- a/lib/prompt.js
+++ b/lib/prompt.js
@@ -474,6 +474,7 @@ prompt.getInput = function (prop, callback) {
     }
 
     var against = {},
+        numericInput,
         isValid;
 
     if (typeof line !== 'string') {
@@ -481,6 +482,17 @@ prompt.getInput = function (prop, callback) {
     }
 
     if (line && line !== '') {
+
+		  //
+		  // Attempt to parse input as a float if the schema expects a number.
+		  //
+		  if (schema.properties[name] && schema.properties[name].type == 'number') {
+		    numericInput = parseFloat(line, 10);
+		    if (numericInput !== 'NaN') {
+		      line = numericInput;
+		    }
+		  }
+
       against[propName] = line;
     }
 
@@ -514,16 +526,6 @@ prompt.getInput = function (prop, callback) {
 //
 prompt._performValidation = function (name, prop, against, schema, line, callback) {
   var numericInput, valid, msg;
-
-  //
-  // Attempt to parse input as a float if the schema expects a number.
-  //
-  if (schema.properties[name] && schema.properties[name].type == 'number') {
-    numericInput = parseFloat(against[name], 10);
-    if (numericInput !== 'NaN') {
-      against[name] = numericInput;
-    }
-  }
 
   try {
     valid = validate(against, schema);


### PR DESCRIPTION
This changes prompt so that it can take numeric input for numeric properties. For example, where this failed previously:

```
josh@onix:~/dev/flatiron/commandful$ node examples/simple.js creature create
info: executing command: creature create
info: prompting user for data
info: define your new creature
prompt: id:  josh
prompt: type:  (dragon) human
prompt: description:  Some dude
prompt: life:  (10) 75
error:   Invalid input for life
```

it now works:

```
josh@onix:~/dev/flatiron/commandful$ node examples/simple.js creature create
info: executing command: creature create
info: prompting user for data
info: define your new creature
prompt: id:  josh
prompt: type:  (dragon) human
prompt: description:  Some dude
prompt: life:  (10) 75
info: about to create creature
info: id  :  josh
info: type  :  human
info: description  :  Some dude
info: life  :  75
info: {"id":"josh","type":"human","description":"Some dude","life":75,"resource":"Creature","_rev":"1-db08506cc5e981cc71873fd35a1851a5"}

```
