### PR TITLE
Fix undefined callback errors.

### DIFF
--- a/lib/prompt.js
+++ b/lib/prompt.js
@@ -163,6 +163,10 @@ prompt.history = function (search) {
 // Gets input from the user via stdin for the specified message(s) `msg`.
 //
 prompt.get = function (schema, callback) {
+  // Ensure there is a proper callback to stop undefined errors.
+  // var callback = _callback(callback);
+  if (!callback) throw new Error('No callback defined.');
+
   //
   // Transforms a full JSON-schema into an array describing path and sub-schemas.
   // Used for iteration purposes.


### PR DESCRIPTION
This fixes instances where a callback may not be defined. Rather than throwing a general undefined error, let's let the person know that they forgot to define a callback.

For instance:

``` js
prompt.start();
prompt.get('test');
```

This would normally throw an error:

```
/home/sly/dev/Node/flatiron/prompt/lib/prompt.js:317
      return err ? done(err) : done(null, result);
                   ^
TypeError: undefined is not a function
    at prompt.get (/home/sly/dev/Node/flatiron/prompt/lib/prompt.js:317:20)
    at async.forEachSeries.iterate (/home/sly/dev/Node/flatiron/prompt/node_modules/utile/node_modules/async/lib/async.js:110:21)
    at assembler (/home/sly/dev/Node/flatiron/prompt/lib/prompt.js:283:18)
    at prompt.get (/home/sly/dev/Node/flatiron/prompt/lib/prompt.js:324:20)
    at prompt.getInput (/home/sly/dev/Node/flatiron/prompt/lib/prompt.js:486:14)
    at onError (/home/sly/dev/Node/flatiron/prompt/node_modules/read/lib/read.js:93:12)
    at Interface.<anonymous> (/home/sly/dev/Node/flatiron/prompt/node_modules/read/lib/read.js:65:5)
    at Interface.EventEmitter.emit (events.js:85:17)
    at Interface._ttyWrite (readline.js:608:16)
    at ReadStream.onkeypress (readline.js:98:10)
```

So, instead of throwing an error.. this proposal would turn it into...

SIGINT:

```
$ node test/test
prompt: test:  User cancelled input.
```

No callback:

```
$ node test/test
prompt: test:  test
User input successful, but no callback defined.
These arguments were returned:
[ { test: 'test' } ]
```

Feedback and suggestions are most definitely welcome.
