### PR TITLE
Modify users input before the running the validation.

### DIFF
--- a/lib/prompt.js
+++ b/lib/prompt.js
@@ -573,11 +573,11 @@ prompt.getInput = function (prop, callback) {
         }
       }
 
-      against[propName] = line;
-    }
+      if (prop && prop.schema.before) {
+        line = prop.schema.before(line);
+      }
 
-    if (prop && prop.schema.before) {
-      line = prop.schema.before(line);
+      against[propName] = line;
     }
 
     // Validate

--- a/test/prompt-test.js
+++ b/test/prompt-test.js
@@ -377,26 +377,29 @@ vows.describe('prompt').addBatch({
       "with a simple string prompt": {
         "that is a property name in prompt.properties": {
           "with a sync function before (.before)": {
-            topic: function() {
-              var that = this;
+            "should be run before validating the input": {
+              topic: function() {
+                var that = this;
 
-              helpers.stdout.once('data', function(msg) {
-                that.msg = msg;
-              });
+                helpers.stdout.once('data', function(msg) {
+                  that.msg = msg;
+                });
 
-              prompt.get({
-                properties: {
-                  fnbefore: {
-                    before: function(v) {
-                      return 'v' + v;
+                prompt.get({
+                  properties: {
+                    fnbefore: {
+                      pattern: /^vfn456$/,
+                      before: function(v) {
+                        return 'v' + v;
+                      }
                     }
                   }
-                }
-              }, this.callback);
-              helpers.stdin.writeNextTick('fn456\n');
-            },
-            "should modify user's input": function(e, result) {
-              assert.equal(result.fnbefore, 'vfn456');
+                }, this.callback);
+                helpers.stdin.writeNextTick('fn456\n');
+              },
+              "should modify user's input": function(e, result) {
+                assert.equal(result.fnbefore, 'vfn456');
+              }
             }
           }
         }


### PR DESCRIPTION
As the title says, it would be a lot more useful if the before() callback was called on the users' input prior to validation. 

I want to be able to do something like:

``` javascript
{
  name: 'date',
  type: 'string',
  required: true,
  format: 'date-time',
  default: 'now',
  before: function(value) {
    return value === 'now' ? new Date().toISOString() : value;
  }
}
```

...but I cannot do that as the validation for the 'date-time' format will fail as it will be using the 'default' value ('now') instead of the transformed date value (new Date().toISOString()). 

I've added a new test to check if the before callback is run prior to validation. 
