### PR TITLE
Call stdin.setRawMode and stdin.resume

### DIFF
--- a/lib/prompt.js
+++ b/lib/prompt.js
@@ -321,7 +321,12 @@ prompt.get = function (schema, callback) {
     prompt.getInput(target, function (err, line) {
       return err ? next(err) : next(null, line);
     });
-  }, callback);
+  }, function () {
+  }, function () {
+    process.stdin.setRawMode(true); 
+    process.stdin.resume();         
+    callback.apply(this, arguments);
+  });
 
   return prompt;
 };


### PR DESCRIPTION
Before callback, call stdin.setRawMode(true) and stdin.resume(). A test case where this is required is when using `keypress` npm module. After callback, `keypress` is not triggered anymore.

This fixes http://stackoverflow.com/q/25268882/1420197
