### PR TITLE
Update license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "test": "vows test/prompt-test.js --spec",
     "test-all": "vows --spec"
   },
+  "license": "MIT",
   "engines": {
     "node": ">= 0.6.6"
   }


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
http://npm1k.org/