### PR TITLE
Add ability to dynamicaly skip a prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ If `ask` returns true the prompt is displayed. otherwise, the default value or e
 ``` js
   var schema = {
     properties: {
-      proxyCredentials: {
+      proxy: {
         description: 'Proxy url',
       },
       proxyCredentials: {

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ Note that, while this structure is similar to that used by prompt 0.1.x, that th
 
 ### Skipping Prompts
 
-Sometimes power users may wish to skip promts and specify all data as command line options.
+Sometimes power users may wish to skip prompts and specify all data as command line options.
 if a value is set as a property of `prompt.override` prompt will use that instead of
 prompting the user.
 
@@ -197,6 +197,45 @@ prompting the user.
   })
 
   //: node prompt-override.js --username USER --email EMAIL
+```
+
+It is also possible to skip prompts dynamically based on previous prompts.
+If an `ask` method is added, prompt will use it to determine if the prompt should be displayed.
+If `ask` returns true the prompt is displayed. otherwise, the default value or empty string are used.
+
+``` js
+  var schema = {
+    properties: {
+      proxyCredentials: {
+        description: 'Proxy url',
+      },
+      proxyCredentials: {
+        description: 'Proxy credentials',
+        ask: function() {
+          // only ask for proxy credentials if a proxy was set
+          return prompt.history('proxy').value > 0;
+        }
+      }
+    }
+  };
+
+  //
+  // Start the prompt
+  //
+  prompt.start();
+
+  //
+  // Get one or two properties from the user, depending on
+  // what the user answered for proxy
+  //
+  prompt.get(schema, function (err, result) {
+    //
+    // Log the results.
+    //
+    console.log('Command-line input received:');
+    console.log('  proxy: ' + result.proxy);
+    console.log('  credentials: ' + result.proxyCredentials);
+  });
 ```
 
 

--- a/examples/dynamic-ask-prompt.js
+++ b/examples/dynamic-ask-prompt.js
@@ -1,0 +1,38 @@
+/*
+ * dynamic-ask-prompt.js: Dynamically decide whether to display prompt.
+ */
+
+var prompt = require('../lib/prompt');
+
+var schema = {
+  properties: {
+    proxy: {
+      description: 'Proxy url'
+    },
+    proxyCredentials: {
+      description: 'Proxy credentials',
+      ask: function() {
+        // only ask for proxy credentials if a proxy was set
+        return prompt.history('proxy').value > 0;
+      }
+    }
+  }
+};
+
+//
+// Start the prompt
+//
+prompt.start();
+
+//
+// Get one or two properties from the user, depending on
+// what the user answered for proxy
+//
+prompt.get(schema, function (err, result) {
+  //
+  // Log the results.
+  //
+  console.log('Command-line input received:');
+  console.log('  proxy: ' + result.proxy);
+  console.log('  credentials: ' + result.proxyCredentials);
+});

--- a/lib/prompt.js
+++ b/lib/prompt.js
@@ -632,17 +632,17 @@ prompt._performValidation = function (name, prop, against, schema, line, callbac
   }
 
   if (!valid.valid) {
-    msg = line !== -1 ? 'Invalid input for ' : 'Invalid command-line input for ';
-
-    if (prompt.colors) {
-      logger.error(msg + name.grey);
-    }
-    else {
-      logger.error(msg + name);
-    }
-
     if (prop.schema.message) {
       logger.error(prop.schema.message);
+    } else {
+      msg = line !== -1 ? 'Invalid input for ' : 'Invalid command-line input for ';
+
+      if (prompt.colors) {
+        logger.error(msg + name.grey);
+      }
+      else {
+        logger.error(msg + name);
+      }
     }
 
     prompt.emit('invalid', prop, line);

--- a/lib/prompt.js
+++ b/lib/prompt.js
@@ -6,12 +6,12 @@
  */
 
 var events = require('events'),
-    readline = require('readline'),
-    utile = require('utile'),
-    async = utile.async,
-    read = require('read'),
-    validate = require('revalidator').validate,
-    winston = require('winston');
+  readline = require('readline'),
+  utile = require('utile'),
+  async = utile.async,
+  read = require('read'),
+  validate = require('revalidator').validate,
+  winston = require('winston');
 
 //
 // Monkey-punch readline.Interface to work-around
@@ -217,7 +217,7 @@ prompt.get = function (schema, callback) {
   //
   function iterate(schema, get, done) {
     var iterator = [],
-        result = {};
+      result = {};
 
     if (typeof schema === 'string') {
       //
@@ -345,12 +345,12 @@ prompt.get = function (schema, callback) {
 //
 prompt.confirm = function (/* msg, options, callback */) {
   var args     = Array.prototype.slice.call(arguments),
-      msg      = args.shift(),
-      callback = args.pop(),
-      opts     = args.shift(),
-      vars     = !Array.isArray(msg) ? [msg] : msg,
-      RX_Y     = /^[yt]{1}/i,
-      RX_YN    = /^[yntf]{1}/i;
+    msg      = args.shift(),
+    callback = args.pop(),
+    opts     = args.shift(),
+    vars     = !Array.isArray(msg) ? [msg] : msg,
+    RX_Y     = /^[yt]{1}/i,
+    RX_YN    = /^[yntf]{1}/i;
 
   function confirm(target, next) {
     var yes = target.yes || RX_Y,
@@ -384,17 +384,17 @@ var tmp = [];
 //
 prompt.getInput = function (prop, callback) {
   var schema = prop.schema || prop,
-      propName = prop.path && prop.path.join(':') || prop,
-      storedSchema = prompt.properties[propName.toLowerCase()],
-      delim = prompt.delimiter,
-      defaultLine,
-      against,
-      hidden,
-      length,
-      valid,
-      name,
-      raw,
-      msg;
+    propName = prop.path && prop.path.join(':') || prop,
+    storedSchema = prompt.properties[propName.toLowerCase()],
+    delim = prompt.delimiter,
+    defaultLine,
+    against,
+    hidden,
+    length,
+    valid,
+    name,
+    raw,
+    msg;
 
   //
   // If there is a stored schema for `propName` in `propmpt.properties`
@@ -416,9 +416,11 @@ prompt.getInput = function (prop, callback) {
   schema = convert(schema);
   defaultLine = schema.default;
   name = prop.description || schema.description || propName;
-  raw = prompt.colors
-    ? [prompt.message, delim + name.grey, delim.grey]
-    : [prompt.message, delim + name, delim];
+  // only show the message delimiter if there is actually a message
+  var prefix = prompt.message && prompt.message.length > 0 ? prompt.message + delim : '',
+    raw = prompt.colors
+      ? [prefix, name.grey, delim.grey]
+      : [prefix, name, delim];
 
   prop = {
     schema: schema,
@@ -450,9 +452,17 @@ prompt.getInput = function (prop, callback) {
     delete prompt.override[propName];
   }
 
+  //
+  // Check if we should skip this prompt
+  //
+  if (typeof prop.schema.ask === 'function' &&
+    !prop.schema.ask()) {
+    return callback(null, prop.schema.default || '');
+  }
+
   var type = (schema.properties && schema.properties[propName] &&
-              schema.properties[propName].type || '').toLowerCase().trim(),
-      wait = type === 'array';
+      schema.properties[propName].type || '').toLowerCase().trim(),
+    wait = type === 'array';
 
   if (type === 'array') {
     length = prop.schema.maxItems;
@@ -511,8 +521,8 @@ prompt.getInput = function (prop, callback) {
     }
 
     var against = {},
-        numericInput,
-        isValid;
+      numericInput,
+      isValid;
 
     if (line !== '') {
 
@@ -721,8 +731,8 @@ prompt._remember = function (property, value) {
 //
 function convert(schema) {
   var newProps = Object.keys(validate.messages),
-      newSchema = false,
-      key;
+    newSchema = false,
+    key;
 
   newProps = newProps.concat(['description', 'dependencies']);
 

--- a/lib/prompt.js
+++ b/lib/prompt.js
@@ -6,12 +6,12 @@
  */
 
 var events = require('events'),
-  readline = require('readline'),
-  utile = require('utile'),
-  async = utile.async,
-  read = require('read'),
-  validate = require('revalidator').validate,
-  winston = require('winston');
+    readline = require('readline'),
+    utile = require('utile'),
+    async = utile.async,
+    read = require('read'),
+    validate = require('revalidator').validate,
+    winston = require('winston');
 
 //
 // Monkey-punch readline.Interface to work-around
@@ -217,7 +217,7 @@ prompt.get = function (schema, callback) {
   //
   function iterate(schema, get, done) {
     var iterator = [],
-      result = {};
+        result = {};
 
     if (typeof schema === 'string') {
       //
@@ -345,12 +345,12 @@ prompt.get = function (schema, callback) {
 //
 prompt.confirm = function (/* msg, options, callback */) {
   var args     = Array.prototype.slice.call(arguments),
-    msg      = args.shift(),
-    callback = args.pop(),
-    opts     = args.shift(),
-    vars     = !Array.isArray(msg) ? [msg] : msg,
-    RX_Y     = /^[yt]{1}/i,
-    RX_YN    = /^[yntf]{1}/i;
+      msg      = args.shift(),
+      callback = args.pop(),
+      opts     = args.shift(),
+      vars     = !Array.isArray(msg) ? [msg] : msg,
+      RX_Y     = /^[yt]{1}/i,
+      RX_YN    = /^[yntf]{1}/i;
 
   function confirm(target, next) {
     var yes = target.yes || RX_Y,
@@ -384,17 +384,17 @@ var tmp = [];
 //
 prompt.getInput = function (prop, callback) {
   var schema = prop.schema || prop,
-    propName = prop.path && prop.path.join(':') || prop,
-    storedSchema = prompt.properties[propName.toLowerCase()],
-    delim = prompt.delimiter,
-    defaultLine,
-    against,
-    hidden,
-    length,
-    valid,
-    name,
-    raw,
-    msg;
+      propName = prop.path && prop.path.join(':') || prop,
+      storedSchema = prompt.properties[propName.toLowerCase()],
+      delim = prompt.delimiter,
+      defaultLine,
+      against,
+      hidden,
+      length,
+      valid,
+      name,
+      raw,
+      msg;
 
   //
   // If there is a stored schema for `propName` in `propmpt.properties`
@@ -461,8 +461,8 @@ prompt.getInput = function (prop, callback) {
   }
 
   var type = (schema.properties && schema.properties[propName] &&
-      schema.properties[propName].type || '').toLowerCase().trim(),
-    wait = type === 'array';
+              schema.properties[propName].type || '').toLowerCase().trim(),
+      wait = type === 'array';
 
   if (type === 'array') {
     length = prop.schema.maxItems;
@@ -521,8 +521,8 @@ prompt.getInput = function (prop, callback) {
     }
 
     var against = {},
-      numericInput,
-      isValid;
+        numericInput,
+        isValid;
 
     if (line !== '') {
 
@@ -731,8 +731,8 @@ prompt._remember = function (property, value) {
 //
 function convert(schema) {
   var newProps = Object.keys(validate.messages),
-    newSchema = false,
-    key;
+      newSchema = false,
+      key;
 
   newProps = newProps.concat(['description', 'dependencies']);
 


### PR DESCRIPTION
It is sometimes useful to control whether to display a prompt to the user based on previous answers.
This PR adds a new `ask` method to a property that enables to skip the prompt based on custom logic.

E.g.:
``` js
  var schema = {
    properties: {
      proxy: {
        description: 'Proxy url',
      },
      proxyCredentials: {
        description: 'Proxy credentials',
        ask: function() {
          // only ask for proxy credentials if a proxy was set
          return prompt.history('proxy').value > 0;
        }
      }
    }
  };
```

I've also included two other minor enhancements:
1. If `prompt.message` is set to an empty string then do not print the delimiter
2. If a property is not valid and has a `message` defined, then do not print the generic "Invalid input for ..." message.

Great project by the way!
