### PR TITLE
Add option to prompt.start to skip SIGINT handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -434,6 +434,12 @@ By default, prompt prompt binds a process-killing event handler to the SIGINT ev
   // Disable prompt's built-in SIGINT handling:
   //
   prompt.start({noHandleSIGINT: true});
+  
+  process.on('SIGINT', function() {
+    console.log("This will execute when you hit CTRL+C");
+    process.exit();
+  });
+```
 
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -298,6 +298,17 @@ var prompt = require('prompt');
 prompt.colors = false;
 ```
 
+## Disabling prompt's built-in SIGINT handling
+
+By default, prompt prompt binds a process-killing event handler to the SIGINT event (CTRL+C). This allows easily exiting from prompts, but can prevent an app from executing other event handlers when an interrupt is received. In order to override this default behavior, pass a `{noHandleSIGINT: true}` option into `prompt.start`.
+
+``` js
+  //
+  // Disable prompt's built-in SIGINT handling:
+  //
+  prompt.start({noHandleSIGINT: true});
+```
+
 ## Installation
 
 ``` bash

--- a/lib/prompt.js
+++ b/lib/prompt.js
@@ -84,7 +84,7 @@ prompt.start = function (options) {
   prompt.delimiter  = options.delimiter  || prompt.delimiter;
   prompt.colors     = options.colors     || prompt.colors;
 
-  if (process.platform !== 'win32') {
+  if (process.platform !== 'win32' && !options.noHandleSIGINT) {
     // windows falls apart trying to deal with SIGINT
     process.on('SIGINT', function () {
       stdout.write('\n');


### PR DESCRIPTION
prompt's default behavior binds a process-killing event handler to the SIGINT event (CTRL+C), preventing an app from executing other event handlers when an interrupt is received. This patch gives the `prompt.start` method a new option (`{noHandleSIGINT: true}`) to disable this behavior.