### PR TITLE
:arrow_up: winston 1.0.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "read": "1.0.x",
     "revalidator": "0.1.x",
     "utile": "0.2.x",
-    "winston": "0.8.x"
+    "winston": "1.0.x"
   },
   "devDependencies": {
     "vows": "0.7.0"


### PR DESCRIPTION
Addresses this issue with bundled PEM keys in older versions of winston: https://github.com/winstonjs/winston/issues/701