### PR TITLE
"default" property now accepts a function that returns a string

### DIFF
--- a/lib/prompt.js
+++ b/lib/prompt.js
@@ -491,6 +491,10 @@ prompt.getInput = function (prop, callback) {
     defaultLine = '';
   }
 
+  if(typeof defaultLine === 'function') {
+    defaultLine = defaultLine();
+  }
+
   //
   // set to string for readline ( will not accept Numbers )
   //

--- a/lib/prompt.js
+++ b/lib/prompt.js
@@ -485,14 +485,17 @@ prompt.getInput = function (prop, callback) {
   prompt.emit('prompt', prop);
 
   //
+  // If defautLine is a function, execute it and store it back to defaultLine.
+  // 
+  if(typeof defaultLine === 'function') {
+    defaultLine = defaultLine();
+  }
+
+  //
   // If there is no default line, set it to an empty string
   //
   if(typeof defaultLine === 'undefined') {
     defaultLine = '';
-  }
-
-  if(typeof defaultLine === 'function') {
-    defaultLine = defaultLine();
   }
 
   //


### PR DESCRIPTION
Changed the "default" to also accept a function that returns a string.  In my use case, this allows the default value to change based on previous input.  For example, we can parse a username or domain from an email address to use as the default value.