### PR TITLE
Update to winston 2.x

### DIFF
--- a/lib/prompt.js
+++ b/lib/prompt.js
@@ -11,7 +11,8 @@ var events = require('events'),
     async = utile.async,
     read = require('read'),
     validate = require('revalidator').validate,
-    winston = require('winston');
+    winston = require('winston'),
+    colors = require('colors/safe');
 
 //
 // Monkey-punch readline.Interface to work-around
@@ -436,7 +437,7 @@ prompt.getInput = function (prop, callback) {
   defaultLine = schema.default;
   name = prop.description || schema.description || propName;
   raw = prompt.colors
-    ? [name.grey, delim.grey]
+    ? [colors.grey(name), colors.grey(delim)]
     : [name, delim];
 
   if (prompt.message)

--- a/package.json
+++ b/package.json
@@ -12,11 +12,12 @@
     "url": "http://github.com/flatiron/prompt.git"
   },
   "dependencies": {
+    "colors": "^1.1.2",
     "pkginfo": "0.x.x",
     "read": "1.0.x",
     "revalidator": "0.1.x",
     "utile": "0.2.x",
-    "winston": "0.8.x"
+    "winston": "2.1.x"
   },
   "devDependencies": {
     "vows": "0.7.0"


### PR DESCRIPTION
Should address #122, though this is 2.x rather than 1.x.

The tests were breaking because `prompt` was using the capability of a transitive dependency called `colors` that was brought in by `winston`. In newer versions of `winston`, they implement `colors` a little differently so it doesn't modifying the `String` prototype. That caused `name.grey` and `delim.grey` to be undefined, which caused the tests to fail.

I've made the dependency on `colors` explicit and updated the prompt colorization to use `colors` without needing the the `String` prototype to be modfied.