### PR TITLE
Missing colors/safe

### DIFF
--- a/lib/prompt.js
+++ b/lib/prompt.js
@@ -494,7 +494,7 @@ prompt.getInput = function (prop, callback) {
       msg = (tmp.length + 1).toString();
     }
     msg += delim;
-    raw.push(prompt.colors ? msg.grey : msg);
+    raw.push(prompt.colors ? colors.grey(msg) : msg);
   }
 
   //
@@ -655,7 +655,7 @@ prompt._performValidation = function (name, prop, against, schema, line, callbac
       msg = line !== -1 ? 'Invalid input for ' : 'Invalid command-line input for ';
 
       if (prompt.colors) {
-        logger.error(msg + name.grey);
+        logger.error(msg + colors.grey(name));
       }
       else {
         logger.error(msg + name);


### PR DESCRIPTION
This fixes two places where colors/safe are not being used, giving `undefined` as output instead of the correct text.