### PR TITLE
Allow functions as defaults

### DIFF
--- a/lib/prompt.js
+++ b/lib/prompt.js
@@ -123,7 +123,7 @@ prompt.stop = function () {
     if (prompt.stopped || !prompt.started) {
         return;
     }
-    
+
     stdin.destroy();
     prompt.emit('stop');
     prompt.stopped = true;
@@ -514,6 +514,13 @@ prompt.getInput = function (prop, callback) {
   // Emit a "prompting" event
   //
   prompt.emit('prompt', prop);
+
+  //
+  // If defaultLine is a function, execute it and store it back to defaultLine
+  //
+  if(typeof defaultLine === 'function') {
+    defaultLine = defaultLine();
+  }
 
   //
   // If there is no default line, set it to an empty string

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -99,6 +99,12 @@ helpers.schema = {
       message: 'riffwabbles can only be letters, numbers, and dashes',
       default: 'foobizzles'
     },
+    functiondefaultpluralanimal: {
+      message: 'function default plural animal',
+      default: function () {
+        return prompt.history('animal').value + 's';
+      }
+    },
     functiondefaulttest: {
       message: 'function default test',
       default: function () {

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -99,6 +99,16 @@ helpers.schema = {
       message: 'riffwabbles can only be letters, numbers, and dashes',
       default: 'foobizzles'
     },
+    functiondefaulttest: {
+      message: 'function default test',
+      default: function () {
+        return 'test';
+      }
+    },
+    functiondefaultundefined: {
+      message: 'function default undefined',
+      default: function () { }
+    },
     number: {
       type: 'number',
       message: 'pick a number, any number',

--- a/test/prompt-test.js
+++ b/test/prompt-test.js
@@ -369,7 +369,7 @@ vows.describe('prompt').addBatch({
     "the get() method": {
       "with a simple string prompt": {
         "that is a property name in prompt.properties": {
-          "with a default value": {
+          "with a string literal default value": {
             topic: function () {
               var that = this;
 
@@ -383,10 +383,69 @@ vows.describe('prompt').addBatch({
             },
             "should prompt to stdout and respond with the default value": function (err, result) {
               assert.isNull(err);
-              assert.isTrue(this.msg.indexOf('riffwabbles') !== -1);
-              assert.isTrue(this.msg.indexOf('(foobizzles)') !== -1);
+              assert.notStrictEqual(this.msg.indexOf('riffwabbles'), -1);
+              assert.notStrictEqual(this.msg.indexOf('(foobizzles)'), -1);
               assert.include(result, 'riffwabbles');
               assert.equal(result['riffwabbles'], schema.properties['riffwabbles'].default);
+            }
+          },
+        }
+      }
+    }
+  }
+}).addBatch({
+  "When using prompt": {
+    "the get() method": {
+      "with a simple string prompt": {
+        "that is a property name in prompt.properties": {
+          "with a function default returning a string literal": {
+            topic: function () {
+              var that = this;
+
+              helpers.stdout.once('data', function (msg) {
+                that.msg = msg;
+              });
+
+              prompt.properties.functiondefaulttest = schema.properties.functiondefaulttest;
+              prompt.get('functionDefaultTest', this.callback);
+              helpers.stdin.writeNextTick('\n');
+            },
+            "should respond with the default value function's return value": function (err, result) {
+              assert.isNull(err);
+              assert.notStrictEqual(this.msg.indexOf('function default test'), -1);
+              assert.notStrictEqual(this.msg.indexOf('(test)'), -1);
+              assert.include(result, 'functionDefaultTest');
+              assert.strictEqual(result['functionDefaultTest'], 'test');
+            }
+          },
+        }
+      }
+    }
+  }
+}).addBatch({
+  "When using prompt": {
+    "the get() method": {
+      "with a simple string prompt": {
+        "that is a property name in prompt.properties": {
+          "with a function default that returns undefined": {
+            topic: function () {
+              var that = this;
+
+              helpers.stdout.once('data', function (msg) {
+                that.msg = msg;
+              });
+
+              prompt.properties.functiondefaultundefined =
+                schema.properties.functiondefaultundefined;
+              prompt.get('functionDefaultUndefined', this.callback);
+              helpers.stdin.writeNextTick('\n');
+            },
+            "should prompt without a default value": function (err, result) {
+              assert.isNull(err);
+              assert.notStrictEqual(this.msg.indexOf('function default undefined'), -1);
+              assert.strictEqual(this.msg.indexOf('('), -1);
+              assert.include(result, 'functionDefaultUndefined');
+              assert.strictEqual(result['functionDefaultUndefined'], '');
             }
           },
         }

--- a/test/prompt-test.js
+++ b/test/prompt-test.js
@@ -427,6 +427,42 @@ vows.describe('prompt').addBatch({
     "the get() method": {
       "with a simple string prompt": {
         "that is a property name in prompt.properties": {
+          "with a function default returning a string literal": {
+            topic: function () {
+              var that = this;
+
+              helpers.stdout.once('data', function (msg) {
+                // we really need the second message, so we'll
+                // ignore the first and look out for the second
+                helpers.stdout.once('data', function (msg) {
+                  that.msg = msg;
+                })
+              });
+
+              prompt.properties.animal = schema.properties.animal;
+              prompt.properties.functiondefaultpluralanimal =
+                schema.properties.functiondefaultpluralanimal;
+              prompt.get(['animal', 'functiondefaultpluralanimal'], this.callback);
+              helpers.stdin.writeSequence(['cat\n', '\n']);
+            },
+            "should respond with the default value function's return value": function (err, result) {
+              assert.isNull(err);
+              assert.notStrictEqual(this.msg.indexOf('function default plural animal'), -1);
+              assert.notStrictEqual(this.msg.indexOf('(cats)'), -1);
+              assert.strictEqual(result['animal'], 'cat');
+              assert.include(result, 'functiondefaultpluralanimal');
+              assert.strictEqual(result['functiondefaultpluralanimal'], 'cats');
+            }
+          },
+        }
+      }
+    }
+  }
+}).addBatch({
+  "When using prompt": {
+    "the get() method": {
+      "with a simple string prompt": {
+        "that is a property name in prompt.properties": {
           "with a function default that returns undefined": {
             topic: function () {
               var that = this;


### PR DESCRIPTION
This is a follow-up to #136, basically adding the requested tests to that pull request. I also cleared up some assert syntax on a related test.

In general, this feature — being able to set a function to a property's `default` — will allow a default value to depend on a prior response from `prompt.history()`.