### PR TITLE
fix #69

### DIFF
--- a/lib/prompt.js
+++ b/lib/prompt.js
@@ -761,9 +761,14 @@ function convert(schema) {
   }
 
   if (!newSchema || schema.validator || schema.warning || typeof schema.empty !== 'undefined') {
-    schema.description = schema.message;
-    schema.message = schema.warning;
-
+    if(typeof schema.message !== 'undefined'){
+      schema.description = schema.message;
+    }
+	  
+    if(typeof schema.warning !== 'undefined'){
+      schema.message = schema.warning;
+    }
+    
     if (typeof schema.validator === 'function') {
       schema.conform = schema.validator;
     } else {


### PR DESCRIPTION
more info in that issue

code example:
``` js
var properties = {
            name: 'theme_name',
            description: 'Theme name(will be used for directory name also)',
            validator: /^[a-zA-Z0-9\s\-]+$/,
            warning: 'Theme name must be only letters, numbers, spaces, or dashes'
        }
```