### PR TITLE
Fixed a callback issue in addProperties

### DIFF
--- a/lib/prompt.js
+++ b/lib/prompt.js
@@ -689,7 +689,7 @@ prompt.addProperties = function (obj, properties, callback) {
   });
 
   if (properties.length === 0) {
-    return callback(obj);
+    return callback(null, obj);
   }
 
   prompt.get(properties, function (err, results) {

--- a/test/prompt-test.js
+++ b/test/prompt-test.js
@@ -649,6 +649,20 @@ vows.describe('prompt').addBatch({
   }
 }).addBatch({
   "When using prompt": {
+    "the addProperties() method": {
+      topic: function () {
+        prompt.addProperties({'foo': 'foo', 'bar': 'bar'}, [], this.callback);
+      },
+      "should return the object as-is when no properties provided": function (err, obj) {
+        assert.isNull(err);
+        assert.isObject(obj);
+        assert.equal(obj.foo, 'foo');
+        assert.equal(obj.bar, 'bar');
+      }
+    }
+  }
+}).addBatch({
+  "When using prompt": {
     "the get() method": {
       "with old schema": {
         topic: function () {


### PR DESCRIPTION
This currently calls back with the intended result as the first parameter, rather than a `null` error, which is what most people are probably expecting in their callbacks.