### PR TITLE
Respect falsy overrides (fixes #151)

### DIFF
--- a/lib/prompt.js
+++ b/lib/prompt.js
@@ -465,7 +465,7 @@ prompt.getInput = function (prop, callback) {
   // Handle overrides here.
   // TODO: Make overrides nestable
   //
-  if (prompt.override && prompt.override[propName]) {
+  if (prompt.override && prompt.override.hasOwnProperty(propName)) {
     if (prompt._performValidation(name, prop, prompt.override, schema, -1, callback)) {
       return callback(null, prompt.override[propName]);
     }

--- a/test/prompt-test.js
+++ b/test/prompt-test.js
@@ -634,6 +634,20 @@ vows.describe('prompt').addBatch({
   }
 }).addBatch({
   "When using prompt": {
+    "the get() method": {
+      "skip prompt with falsy prompt.overide": {
+        topic: function () {
+          prompt.override = { coconihet: false }
+          prompt.get('coconihet', this.callback);
+        },
+        "skips prompt and uses overide": function (err, results) {
+          assert.equal(results.coconihet, false)
+        }
+      }
+    }
+  }
+}).addBatch({
+  "When using prompt": {
     "the addProperties() method": {
       topic: function () {
         prompt.addProperties({}, ['foo', 'bar'], this.callback);


### PR DESCRIPTION
Before this PR, overrides were only applied if the value of the override was truthy. This meant that trying to override a boolean with a value of `false` did not work (see discussion in #151).

This PR changes the test for existence of an override from using `&& prompt.override[propName]` to using `&& prompt.hasOwnProperty(propName)`, so that the override is respected for any property which has a matching key in the override object.

I also added a regression test.