### PR TITLE
Promise support

### DIFF
--- a/lib/prompt.js
+++ b/lib/prompt.js
@@ -182,168 +182,178 @@ prompt.history = function (search) {
 // Gets input from the user via stdin for the specified message(s) `msg`.
 //
 prompt.get = function (schema, callback) {
-  //
-  // Transforms a full JSON-schema into an array describing path and sub-schemas.
-  // Used for iteration purposes.
-  //
-  function untangle(schema, path) {
-    var results = [];
-    path = path || [];
+    return new Promise( function(resolve, reject) {
 
-    if (schema.properties) {
       //
-      // Iterate over the properties in the schema and use recursion
-      // to process sub-properties.
+      // Transforms a full JSON-schema into an array describing path and sub-schemas.
+      // Used for iteration purposes.
       //
-      Object.keys(schema.properties).forEach(function (key) {
-        var obj = {};
-        obj[key] = schema.properties[key];
+      function untangle(schema, path) {
+        var results = [];
+        path = path || [];
+
+        if (schema.properties) {
+          //
+          // Iterate over the properties in the schema and use recursion
+          // to process sub-properties.
+          //
+          Object.keys(schema.properties).forEach(function (key) {
+            var obj = {};
+            obj[key] = schema.properties[key];
+
+            //
+            // Concat a sub-untangling to the results.
+            //
+            results = results.concat(untangle(obj[key], path.concat(key)));
+          });
+
+          // Return the results.
+          return results;
+        }
 
         //
-        // Concat a sub-untangling to the results.
+        // This is a schema "leaf".
         //
-        results = results.concat(untangle(obj[key], path.concat(key)));
-      });
+        return {
+          path: path,
+          schema: schema
+        };
+      }
 
-      // Return the results.
-      return results;
-    }
+      //
+      // Iterate over the values in the schema, represented as
+      // a legit single-property object subschemas. Accepts `schema`
+      // of the forms:
+      //
+      //    'prop-name'
+      //
+      //    ['string-name', { path: ['or-well-formed-subschema'], properties: ... }]
+      //
+      //    { path: ['or-well-formed-subschema'], properties: ... ] }
+      //
+      //    { properties: { 'schema-with-no-path' } }
+      //
+      // And transforms them all into
+      //
+      //    { path: ['path', 'to', 'property'], properties: { path: { to: ...} } }
+      //
+      function iterate(schema, get, done) {
+        var iterator = [],
+            result = {};
 
-    //
-    // This is a schema "leaf".
-    //
-    return {
-      path: path,
-      schema: schema
-    };
-  }
-
-  //
-  // Iterate over the values in the schema, represented as
-  // a legit single-property object subschemas. Accepts `schema`
-  // of the forms:
-  //
-  //    'prop-name'
-  //
-  //    ['string-name', { path: ['or-well-formed-subschema'], properties: ... }]
-  //
-  //    { path: ['or-well-formed-subschema'], properties: ... ] }
-  //
-  //    { properties: { 'schema-with-no-path' } }
-  //
-  // And transforms them all into
-  //
-  //    { path: ['path', 'to', 'property'], properties: { path: { to: ...} } }
-  //
-  function iterate(schema, get, done) {
-    var iterator = [],
-        result = {};
-
-    if (typeof schema === 'string') {
-      //
-      // We can iterate over a single string.
-      //
-      iterator.push({
-        path: [schema],
-        schema: prompt.properties[schema.toLowerCase()] || {}
-      });
-    }
-    else if (Array.isArray(schema)) {
-      //
-      // An array of strings and/or single-prop schema and/or no-prop schema.
-      //
-      iterator = schema.map(function (element) {
-        if (typeof element === 'string') {
-          return {
-            path: [element],
-            schema: prompt.properties[element.toLowerCase()] || {}
-          };
+        if (typeof schema === 'string') {
+          //
+          // We can iterate over a single string.
+          //
+          iterator.push({
+            path: [schema],
+            schema: prompt.properties[schema.toLowerCase()] || {}
+          });
         }
-        else if (element.properties) {
-          return {
-            path: [Object.keys(element.properties)[0]],
-            schema: element.properties[Object.keys(element.properties)[0]]
-          };
+        else if (Array.isArray(schema)) {
+          //
+          // An array of strings and/or single-prop schema and/or no-prop schema.
+          //
+          iterator = schema.map(function (element) {
+            if (typeof element === 'string') {
+              return {
+                path: [element],
+                schema: prompt.properties[element.toLowerCase()] || {}
+              };
+            }
+            else if (element.properties) {
+              return {
+                path: [Object.keys(element.properties)[0]],
+                schema: element.properties[Object.keys(element.properties)[0]]
+              };
+            }
+            else if (element.path && element.schema) {
+              return element;
+            }
+            else {
+              return {
+                path: [element.name || 'question'],
+                schema: element
+              };
+            }
+          });
         }
-        else if (element.path && element.schema) {
-          return element;
+        else if (schema.properties) {
+          //
+          // Or a complete schema `untangle` it for use.
+          //
+          iterator = untangle(schema);
         }
         else {
-          return {
-            path: [element.name || 'question'],
-            schema: element
-          };
-        }
-      });
-    }
-    else if (schema.properties) {
-      //
-      // Or a complete schema `untangle` it for use.
-      //
-      iterator = untangle(schema);
-    }
-    else {
-      //
-      // Or a partial schema and path.
-      // TODO: Evaluate need for this option.
-      //
-      iterator = [{
-        schema: schema.schema ? schema.schema : schema,
-        path: schema.path || [schema.name || 'question']
-      }];
-    }
-
-    //
-    // Now, iterate and assemble the result.
-    //
-    async.forEachSeries(iterator, function (branch, next) {
-      get(branch, function assembler(err, line) {
-        if (err) {
-          return next(err);
+          //
+          // Or a partial schema and path.
+          // TODO: Evaluate need for this option.
+          //
+          iterator = [{
+            schema: schema.schema ? schema.schema : schema,
+            path: schema.path || [schema.name || 'question']
+          }];
         }
 
-        function build(path, line) {
-          var obj = {};
-          if (path.length) {
-            obj[path[0]] = build(path.slice(1), line);
-            return obj;
-          }
-
-          return line;
-        }
-
-        function attach(obj, attr) {
-          var keys;
-          if (typeof attr !== 'object' || attr instanceof Array) {
-            return attr;
-          }
-
-          keys = Object.keys(attr);
-          if (keys.length) {
-            if (!obj[keys[0]]) {
-              obj[keys[0]] = {};
+        //
+        // Now, iterate and assemble the result.
+        //
+        async.forEachSeries(iterator, function (branch, next) {
+          get(branch, function assembler(err, line) {
+            if (err) {
+              return next(err);
             }
-            obj[keys[0]] = attach(obj[keys[0]], attr[keys[0]]);
+
+            function build(path, line) {
+              var obj = {};
+              if (path.length) {
+                obj[path[0]] = build(path.slice(1), line);
+                return obj;
+              }
+
+              return line;
+            }
+
+            function attach(obj, attr) {
+              var keys;
+              if (typeof attr !== 'object' || attr instanceof Array) {
+                return attr;
+              }
+
+              keys = Object.keys(attr);
+              if (keys.length) {
+                if (!obj[keys[0]]) {
+                  obj[keys[0]] = {};
+                }
+                obj[keys[0]] = attach(obj[keys[0]], attr[keys[0]]);
+              }
+
+              return obj;
+            }
+
+            result = attach(result, build(branch.path, line));
+            next();
+          });
+        }, function (err) {
+          return err ? done(err) : done(null, result);
+        });
+      }
+
+      var iterator = function get(target, next) {
+        prompt.getInput(target, function (err, line) {
+          return err ? next(err) : next(null, line);
+        });
+      };
+
+      if(!callback) {
+          callback = function(err, data) {
+              if(err) return reject(err);
+              return resolve(data);
           }
+      }
 
-          return obj;
-        }
-
-        result = attach(result, build(branch.path, line));
-        next();
-      });
-    }, function (err) {
-      return err ? done(err) : done(null, result);
+      return iterate(schema, iterator, callback);
     });
-  }
-
-  iterate(schema, function get(target, next) {
-    prompt.getInput(target, function (err, line) {
-      return err ? next(err) : next(null, line);
-    });
-  }, callback);
-
-  return prompt;
 };
 
 //
@@ -372,23 +382,26 @@ prompt.confirm = function (/* msg, options, callback */) {
       RX_Y     = /^[yt]{1}/i,
       RX_YN    = /^[yntf]{1}/i;
 
-  function confirm(target, next) {
-    var yes = target.yes || RX_Y,
-      options = utile.mixin({
-        description: typeof target === 'string' ? target : target.description||'yes/no',
-        pattern: target.pattern || RX_YN,
-        name: 'confirm',
-        message: target.message || 'yes/no'
-      }, opts || {});
+  return new Promise( function(resolve, reject) {
+      function confirm(target, next) {
+        var yes = target.yes || RX_Y,
+          options = utile.mixin({
+            description: typeof target === 'string' ? target : target.description||'yes/no',
+            pattern: target.pattern || RX_YN,
+            name: 'confirm',
+            message: target.message || 'yes/no'
+          }, opts || {});
 
 
-    prompt.get([options], function (err, result) {
-      next(err ? false : yes.test(result[options.name]));
-    });
-  }
+        prompt.get([options], function (err, result) {
+          next(err ? false : yes.test(result[options.name]));
+        });
+      }
 
-  async.rejectSeries(vars, confirm, function(result) {
-    callback(null, result.length===0);
+      async.rejectSeries(vars, confirm, function(result) {
+        return callback(null, result.length===0);
+        //return resolve(result.length===0);
+      });
   });
 };
 
@@ -403,236 +416,243 @@ var tmp = [];
 // Gets input from the user via stdin for the specified message `msg`.
 //
 prompt.getInput = function (prop, callback) {
-  var schema = prop.schema || prop,
-      propName = prop.path && prop.path.join(':') || prop,
-      storedSchema = prompt.properties[propName.toLowerCase()],
-      delim = prompt.delimiter,
-      defaultLine,
-      against,
-      hidden,
-      length,
-      valid,
-      name,
-      raw,
-      msg;
+  return new Promise( function(resolve, reject) {
+      var schema = prop.schema || prop,
+          propName = prop.path && prop.path.join(':') || prop,
+          storedSchema = prompt.properties[propName.toLowerCase()],
+          delim = prompt.delimiter,
+          defaultLine,
+          against,
+          hidden,
+          length,
+          valid,
+          name,
+          raw,
+          msg;
 
-  //
-  // If there is a stored schema for `propName` in `propmpt.properties`
-  // then use it.
-  //
-  if (schema instanceof Object && !Object.keys(schema).length &&
-    typeof storedSchema !== 'undefined') {
-    schema = storedSchema;
-  }
-
-  //
-  // Build a proper validation schema if we just have a string
-  // and no `storedSchema`.
-  //
-  if (typeof prop === 'string' && !storedSchema) {
-    schema = {};
-  }
-
-  schema = convert(schema);
-  defaultLine = schema.default;
-  name = prop.description || schema.description || propName;
-  raw = prompt.colors
-    ? [colors.grey(name), colors.grey(delim)]
-    : [name, delim];
-
-  if (prompt.message)
-    raw.unshift(prompt.message, delim);
-
-  prop = {
-    schema: schema,
-    path: propName.split(':')
-  };
-
-  //
-  // If the schema has no `properties` value then set
-  // it to an object containing the current schema
-  // for `propName`.
-  //
-  if (!schema.properties) {
-    schema = (function () {
-      var obj = { properties: {} };
-      obj.properties[propName] = schema;
-      return obj;
-    })();
-  }
-
-  //
-  // Handle overrides here.
-  // TODO: Make overrides nestable
-  //
-  if (prompt.override && prompt.override.hasOwnProperty(propName)) {
-    if (prompt._performValidation(name, prop, prompt.override, schema, -1, callback)) {
-      return callback(null, prompt.override[propName]);
-    }
-
-    delete prompt.override[propName];
-  }
-
-  //
-  // Check if we should skip this prompt
-  //
-  if (typeof prop.schema.ask === 'function' &&
-    !prop.schema.ask()) {
-    return callback(null, prop.schema.default || '');
-  }
-
-  var type = (schema.properties && schema.properties[propName] &&
-              schema.properties[propName].type || '').toLowerCase().trim(),
-      wait = type === 'array';
-
-  if (type === 'array') {
-    length = prop.schema.maxItems;
-    if (length) {
-      msg = (tmp.length + 1).toString() + '/' + length.toString();
-    }
-    else {
-      msg = (tmp.length + 1).toString();
-    }
-    msg += delim;
-    raw.push(prompt.colors ? colors.grey(msg) : msg);
-  }
-
-  //
-  // Calculate the raw length and colorize the prompt
-  //
-  length = raw.join('').length;
-  raw[0] = raw[0];
-  msg = raw.join('');
-
-  if (schema.help) {
-    schema.help.forEach(function (line) {
-      logger.help(line);
-    });
-  }
-
-  //
-  // Emit a "prompting" event
-  //
-  prompt.emit('prompt', prop);
-
-  //
-  // If defaultLine is a function, execute it and store it back to defaultLine
-  //
-  if(typeof defaultLine === 'function') {
-    defaultLine = defaultLine();
-  }
-
-  //
-  // If there is no default line, set it to an empty string
-  //
-  if(typeof defaultLine === 'undefined') {
-    defaultLine = '';
-  }
-
-  //
-  // set to string for readline ( will not accept Numbers )
-  //
-  defaultLine = defaultLine.toString();
-
-  //
-  // Make the actual read
-  //
-  read({
-    prompt: msg,
-    silent: prop.schema && prop.schema.hidden,
-    replace: prop.schema && prop.schema.replace,
-    default: defaultLine,
-    input: stdin,
-    output: stdout
-  }, function (err, line) {
-    if (err && wait === false) {
-      return callback(err);
-    }
-
-    var against = {},
-        numericInput,
-        isValid;
-
-    if (line !== '') {
-
-      if (schema.properties[propName]) {
-        var type = (schema.properties[propName].type || '').toLowerCase().trim() || undefined;
-
-        //
-        // If type is some sort of numeric create a Number object to pass to revalidator
-        //
-        if (type === 'number' || type === 'integer') {
-          line = Number(line);
-        }
-
-        //
-        // Attempt to parse input as a boolean if the schema expects a boolean
-        //
-        if (type == 'boolean') {
-          if(line.toLowerCase() === "true" || line.toLowerCase() === 't') {
-            line = true;
-          } else if(line.toLowerCase() === "false" || line.toLowerCase() === 'f') {
-            line = false;
-          }
-        }
-
-        //
-        // If the type is an array, wait for the end. Fixes #54
-        //
-        if (type == 'array') {
-          var length = prop.schema.maxItems;
-          if (err) {
-            if (err.message == 'canceled') {
-              wait = false;
-              stdout.write('\n');
-            }
-          }
-          else {
-            if (length) {
-              if (tmp.length + 1 < length) {
-                isValid = false;
-                wait = true;
-              }
-              else {
-                isValid = true;
-                wait = false;
-              }
-            }
-            else {
-              isValid = false;
-              wait = true;
-            }
-            tmp.push(line);
-          }
-          line = tmp;
-        }
+      //
+      // If there is a stored schema for `propName` in `propmpt.properties`
+      // then use it.
+      //
+      if (schema instanceof Object && !Object.keys(schema).length &&
+        typeof storedSchema !== 'undefined') {
+        schema = storedSchema;
       }
 
-      against[propName] = line;
-    }
+      //
+      // Build a proper validation schema if we just have a string
+      // and no `storedSchema`.
+      //
+      if (typeof prop === 'string' && !storedSchema) {
+        schema = {};
+      }
 
-    if (prop && prop.schema.before) {
-      line = prop.schema.before(line);
-    }
+      schema = convert(schema);
+      defaultLine = schema.default;
+      name = prop.description || schema.description || propName;
+      raw = prompt.colors
+        ? [colors.grey(name), colors.grey(delim)]
+        : [name, delim];
 
-    // Validate
-    if (isValid === undefined) isValid = prompt._performValidation(name, prop, against, schema, line, callback);
+      if (prompt.message)
+        raw.unshift(prompt.message, delim);
 
-    if (!isValid) {
-      return prompt.getInput(prop, callback);
-    }
+      prop = {
+        schema: schema,
+        path: propName.split(':')
+      };
 
-    //
-    // Log the resulting line, append this `property:value`
-    // pair to the history for `prompt` and respond to
-    // the callback.
-    //
-    logger.input(line.yellow);
-    prompt._remember(propName, line);
-    callback(null, line);
+      //
+      // If the schema has no `properties` value then set
+      // it to an object containing the current schema
+      // for `propName`.
+      //
+      if (!schema.properties) {
+        schema = (function () {
+          var obj = { properties: {} };
+          obj.properties[propName] = schema;
+          return obj;
+        })();
+      }
 
-    // Make sure `tmp` is emptied
-    tmp = [];
+      //
+      // Handle overrides here.
+      // TODO: Make overrides nestable
+      //
+      if (prompt.override && prompt.override.hasOwnProperty(propName)) {
+        if (prompt._performValidation(name, prop, prompt.override, schema, -1, callback)) {
+          if(callback) return callback(null, prompt.override[propName]);
+          return resolve(prompt.override[propName]);
+        }
+
+        delete prompt.override[propName];
+      }
+
+      //
+      // Check if we should skip this prompt
+      //
+      if (typeof prop.schema.ask === 'function' &&
+        !prop.schema.ask()) {
+        if(callback) return callback(null, prop.schema.default || '');
+        return resolve(prop.schema.default || '');
+      }
+
+      var type = (schema.properties && schema.properties[propName] &&
+                  schema.properties[propName].type || '').toLowerCase().trim(),
+          wait = type === 'array';
+
+      if (type === 'array') {
+        length = prop.schema.maxItems;
+        if (length) {
+          msg = (tmp.length + 1).toString() + '/' + length.toString();
+        }
+        else {
+          msg = (tmp.length + 1).toString();
+        }
+        msg += delim;
+        raw.push(prompt.colors ? colors.grey(msg) : msg);
+      }
+
+      //
+      // Calculate the raw length and colorize the prompt
+      //
+      length = raw.join('').length;
+      raw[0] = raw[0];
+      msg = raw.join('');
+
+      if (schema.help) {
+        schema.help.forEach(function (line) {
+          logger.help(line);
+        });
+      }
+
+      //
+      // Emit a "prompting" event
+      //
+      prompt.emit('prompt', prop);
+
+      //
+      // If defaultLine is a function, execute it and store it back to defaultLine
+      //
+      if(typeof defaultLine === 'function') {
+        defaultLine = defaultLine();
+      }
+
+      //
+      // If there is no default line, set it to an empty string
+      //
+      if(typeof defaultLine === 'undefined') {
+        defaultLine = '';
+      }
+
+      //
+      // set to string for readline ( will not accept Numbers )
+      //
+      defaultLine = defaultLine.toString();
+
+      //
+      // Make the actual read
+      //
+      read({
+        prompt: msg,
+        silent: prop.schema && prop.schema.hidden,
+        replace: prop.schema && prop.schema.replace,
+        default: defaultLine,
+        input: stdin,
+        output: stdout
+      }, function (err, line) {
+        if (err && wait === false) {
+          if(callback) return callback(err);
+          return reject(err);
+        }
+
+        var against = {},
+            numericInput,
+            isValid;
+
+        if (line !== '') {
+
+          if (schema.properties[propName]) {
+            var type = (schema.properties[propName].type || '').toLowerCase().trim() || undefined;
+
+            //
+            // If type is some sort of numeric create a Number object to pass to revalidator
+            //
+            if (type === 'number' || type === 'integer') {
+              line = Number(line);
+            }
+
+            //
+            // Attempt to parse input as a boolean if the schema expects a boolean
+            //
+            if (type == 'boolean') {
+              if(line.toLowerCase() === "true" || line.toLowerCase() === 't') {
+                line = true;
+              } else if(line.toLowerCase() === "false" || line.toLowerCase() === 'f') {
+                line = false;
+              }
+            }
+
+            //
+            // If the type is an array, wait for the end. Fixes #54
+            //
+            if (type == 'array') {
+              var length = prop.schema.maxItems;
+              if (err) {
+                if (err.message == 'canceled') {
+                  wait = false;
+                  stdout.write('\n');
+                }
+              }
+              else {
+                if (length) {
+                  if (tmp.length + 1 < length) {
+                    isValid = false;
+                    wait = true;
+                  }
+                  else {
+                    isValid = true;
+                    wait = false;
+                  }
+                }
+                else {
+                  isValid = false;
+                  wait = true;
+                }
+                tmp.push(line);
+              }
+              line = tmp;
+            }
+          }
+
+          against[propName] = line;
+        }
+
+        if (prop && prop.schema.before) {
+          line = prop.schema.before(line);
+        }
+
+        // Validate
+        if (isValid === undefined) isValid = prompt._performValidation(name, prop, against, schema, line, callback);
+
+        if (!isValid) {
+          return prompt.getInput(prop, callback);
+        }
+
+        //
+        // Log the resulting line, append this `property:value`
+        // pair to the history for `prompt` and respond to
+        // the callback.
+        //
+        logger.input(line.yellow);
+        prompt._remember(propName, line);
+
+        // Make sure `tmp` is emptied
+        tmp = [];
+
+        if(callback) return callback(null, line);
+        return resolve(line);
+      });
   });
 };
 
@@ -684,45 +704,49 @@ prompt._performValidation = function (name, prop, against, schema, line, callbac
 // have a value for the property. Responds with the modified object.
 //
 prompt.addProperties = function (obj, properties, callback) {
-  properties = properties.filter(function (prop) {
-    return typeof obj[prop] === 'undefined';
-  });
+  return new Promise( function(resolve, reject) {
+      properties = properties.filter(function (prop) {
+        return typeof obj[prop] === 'undefined';
+      });
 
-  if (properties.length === 0) {
-    return callback(null, obj);
-  }
-
-  prompt.get(properties, function (err, results) {
-    if (err) {
-      return callback(err);
-    }
-    else if (!results) {
-      return callback(null, obj);
-    }
-
-    function putNested (obj, path, value) {
-      var last = obj, key;
-
-      while (path.length > 1) {
-        key = path.shift();
-        if (!last[key]) {
-          last[key] = {};
-        }
-
-        last = last[key];
+      if (properties.length === 0) {
+        if(callback) return callback(null, obj);
+        return resolve(obj);
       }
 
-      last[path.shift()] = value;
-    }
+      prompt.get(properties, function (err, results) {
+        if (err) {
+          if(callback) return callback(err);
+          return reject(err);
+        }
+        else if (!results) {
+          if(callback) return callback(null, obj);
+          return resolve(obj);
+        }
 
-    Object.keys(results).forEach(function (key) {
-      putNested(obj, key.split('.'), results[key]);
-    });
+        function putNested (obj, path, value) {
+          var last = obj, key;
 
-    callback(null, obj);
+          while (path.length > 1) {
+            key = path.shift();
+            if (!last[key]) {
+              last[key] = {};
+            }
+
+            last = last[key];
+          }
+
+          last[path.shift()] = value;
+        }
+
+        Object.keys(results).forEach(function (key) {
+          putNested(obj, key.split('.'), results[key]);
+        });
+
+        if(callback) return callback(null, obj);
+        return resolve(obj);
+      });
   });
-
-  return prompt;
 };
 
 //

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "winston": "2.x"
   },
   "devDependencies": {
-    "vows": "0.7.0"
+    "vows": "^0.7.0"
   },
   "main": "./lib/prompt",
   "scripts": {

--- a/test/prompt-test.js
+++ b/test/prompt-test.js
@@ -57,6 +57,36 @@ vows.describe('prompt').addBatch({
 }).addBatch({
   "When using prompt": {
     "the getInput() method": {
+      "with a simple string prompt": {
+          "using promises": {
+            topic: function () {
+              var that = this;
+              helpers.stdout.once('data', function (msg) {
+                that.msg = msg;
+              })
+
+              prompt.getInput('test input')
+              .then(function(input) {
+                  return that.callback(null, input);
+              })
+              .catch(function(err) {
+                  return that.callback(err, null);
+              });
+
+              helpers.stdin.writeNextTick('test value\n');
+            },
+            "should prompt to stdout and respond with data": function (err, input) {
+              assert.isNull(err);
+              assert.equal(input, 'test value');
+              assert.isTrue(this.msg.indexOf('test input') !== -1);
+            }
+          }
+      }
+    }
+  }
+}).addBatch({
+  "When using prompt": {
+    "the getInput() method": {
       "with any field that is not supposed to be empty": {
         "and we don't provide any input": {
           topic: function () {


### PR DESCRIPTION
This adds in an initial take on Promise support using native node promises. 

In reference to #81, Promises have since become a standard pattern and well supported in Node LTS and later, and in addition no longer require additional abstractions such as Q or bluebird, and the spec itself has become reasonably standard (at least the usage of it here).

This maintains the callback Interface as a first-class-citizen and only falls back to Promises when callbacks aren't used, supporting both approaches without any additional deps. 

Also of mention, #176 which duplicates the upvoted ask in #81.