### PR TITLE
triggering sigint on windows

### DIFF
--- a/lib/prompt.js
+++ b/lib/prompt.js
@@ -92,6 +92,16 @@ prompt.start = function (options) {
       stdout.write('\n');
       process.exit(1);
     });
+  } else {
+    // listen for the "Ctrl+C" key combination and trigger process event.
+    // See https://stackoverflow.com/questions/10021373/what-is-the-windows-equivalent-of-process-onsigint-in-node-js
+    stdin.on('keypress', function(char, key) {
+      if (key && key.ctrl && key.name == 'c') {
+        stdout.write('\n');
+        process.emit("SIGINT");
+        process.exit(1);
+      }
+    });
   }
 
   prompt.emit('start');


### PR DESCRIPTION
SIGINT node event is not supported on windows at the moment. Thus, we need to listen for the key combination and trigger the event manually.