### PR TITLE
promisify prompt.get

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 node_modules/
 node_modules/*
 npm-debug.log
+
+package-lock.json

--- a/README.md
+++ b/README.md
@@ -46,6 +46,12 @@ This will result in the following command-line output:
     email: some-user@some-place.org
 ```
 
+If no callback is passed to `prompt.get(schema)`, then it returns a `Promise`, so you can also write:
+```js
+const {username, email} = await prompt.get(['username', 'email']);
+```
+
+
 ### Prompting with Validation, Default Values, and More (Complex Properties)
 In addition to prompting the user with simple string prompts, there is a robust API for getting and validating complex information from a command-line prompt. Here's a quick sample:
 

--- a/lib/prompt.js
+++ b/lib/prompt.js
@@ -192,6 +192,16 @@ prompt.history = function (search) {
 // Gets input from the user via stdin for the specified message(s) `msg`.
 //
 prompt.get = function (schema, callback) {
+  if (typeof callback === 'function') return prompt._get(schema, callback);
+
+  return new Promise(function (resolve, reject) {
+    prompt._get(schema, function (err, result) {
+      return err ? reject(err) : resolve(result);
+    });
+  });
+};
+
+prompt._get = function (schema, callback) {
   //
   // Transforms a full JSON-schema into an array describing path and sub-schemas.
   // Used for iteration purposes.

--- a/test/prompt-test.js
+++ b/test/prompt-test.js
@@ -12,6 +12,10 @@ var assert = require('assert'),
     macros = require('./macros'),
     schema = helpers.schema;
 
+// fix for vows, util.print/puts was removed from node
+require('util').print = console.log;
+require('util').puts = console.log;
+
 // A helper to pass fragments of our schema into prompt as full schemas.
 function grab () {
   var names = [].slice.call(arguments),
@@ -744,6 +748,22 @@ vows.describe('prompt').addBatch({
       topic: function () {
         prompt.override = { xyz: 468, abc: 123 }
         prompt.get(['xyz', 'abc'], this.callback);
+      },
+      "should respond with overrides": function (err, results) {
+        assert.isNull(err);
+        assert.deepEqual(results, { xyz: 468, abc: 123 });
+      }
+    }
+  }
+}).addBatch({
+  "when using prompt": {
+    "the get() method also works as a Promise": {
+      topic: function () {
+        var that = this;
+
+        prompt.override = { xyz: 468, abc: 123 };
+        prompt.get(['xyz', 'abc'])
+          .then(function (result) { return that.callback(null, result); });
       },
       "should respond with overrides": function (err, results) {
         assert.isNull(err);


### PR DESCRIPTION
@gangstead Hi, could you check this very small PR?

It just promisifies `prompt.get` (if no callback passed)

it'll help for https://github.com/flatiron/prompt/issues/170

We have to do 
```js
const prompt = require('prompt');

const getPrompt = require('util').promisify(prompt.get).bind(prompt);
```

every time we use prompt, so that PR would be cool