### PR TITLE
"TypeError: Cannot read property 'yellow' of undefined" improved error messaging

### DIFF
--- a/lib/prompt.js
+++ b/lib/prompt.js
@@ -632,10 +632,16 @@ prompt.getInput = function (prop, callback) {
 
       against[propName] = line;
     }
-
+      
+   // if 'before' function is defined, run the function before continuing
+   // if prop.schema.before(line) is undefined, throw helpful error message
     if (prop && prop.schema.before) {
-      line = prop.schema.before(line);
-    }
+        line = prop.schema.before(line);
+        if (!line)
+          throw Error(
+            "'before' property function in prompt schema returns undefined"
+          );
+      }
 
     // Validate
     if (isValid === undefined) isValid = prompt._performValidation(name, prop, against, schema, line, callback);


### PR DESCRIPTION
Error response to an undefined return from the "before" function in a schema is unhelpful and difficult to debug
Throws an error that provides more clarity for easier debugging, as prior error provides no information on what actually went wrong.

prior error message:
`TypeError: Cannot read property 'yellow' of undefined
    at D:\[project]\node_modules\prompt\lib\prompt.js:623:23
    at Interface.onLine (D:\[project]\node_modules\read\lib\read.js:111:5)
    at Interface.emit (events.js:315:20)
    at Interface._onLine (readline.js:329:10)
    at Interface._line (readline.js:658:8)
    at Interface._ttyWrite (readline.js:1003:14)
    at ReadStream.onkeypress (readline.js:205:10)
    at ReadStream.emit (events.js:315:20)
    at emitKeys (internal/readline/utils.js:335:14)
    at emitKeys.next (<anonymous>)`

new error message:
`Error: 'before' property function in prompt schema returns undefined
    at D:\[project]\node_modules\prompt\lib\prompt.js:612:24
    at Interface.onLine (D:\[project]\node_modules\read\lib\read.js:111:5)
    at Interface.emit (events.js:315:20)
    at Interface._onLine (readline.js:329:10)
    at Interface._line (readline.js:658:8)
    at Interface._ttyWrite (readline.js:1003:14)
    at ReadStream.onkeypress (readline.js:205:10)
    at ReadStream.emit (events.js:315:20)
    at emitKeys (internal/readline/utils.js:335:14)
    at emitKeys.next (<anonymous>)`