### PR TITLE
fix: winston warning by setting version to 2.4.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "read": "1.0.x",
     "revalidator": "0.1.x",
     "utile": "0.3.x",
-    "winston": "2.x"
+    "winston": "2.4.5"
   },
   "devDependencies": {
     "vows": "0.7.0"


### PR DESCRIPTION
This PR bumps winston version to 2.4.5. Which fixes the warning produce in Node 14 and higher.
