### PR TITLE
fix: pin the version of `colors` dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   ],
   "dependencies": {
     "async": "~0.9.0",
-    "colors": "^1.1.2",
+    "colors": "1.4.0",
     "read": "1.0.x",
     "revalidator": "0.1.x",
     "winston": "2.x"


### PR DESCRIPTION
closes #220
closes #221


`colors` was intentionally compromised by the author. The latest working version is `1.4.0`. This is a hotfix.

![image](https://user-images.githubusercontent.com/13461315/148703991-ab465d30-52a6-4296-8d15-50e76617734d.png)

![image](https://user-images.githubusercontent.com/13461315/148704015-d08e1056-2fc9-41c8-9e86-7ae4a227fb90.png)


The real fix would be replacing `colors` by another lib like [`chalk`](https://github.com/microsoft/playwright/issues/11272#issuecomment-1008240685) or `colorette` tho.

![image](https://user-images.githubusercontent.com/13461315/148703843-93ac788a-bbf9-462f-a114-c9760ba40edf.png)

---

more on this topic: https://snyk.io/blog/open-source-maintainer-pulls-the-plug-on-npm-packages-colors-and-faker-now-what/