### PR TITLE
Update colors to maintained version

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,12 +316,12 @@ The default `prompt.message` is "prompt," the default `prompt.delimiter` is
 ": ", and the default `property.message` is `property.name`.
 Changing these allows you to customize the appearance of your prompts! In
 addition, prompt supports ANSI color codes via the
-[colors module](https://github.com/Marak/colors.js) for custom colors. For a
+[colors module](https://github.com/DABH/colors.js) for custom colors. For a
 very colorful example:
 
 ``` js
   var prompt = require("prompt");
-  var colors = require("colors/safe");
+  var colors = require("@colors/colors/safe");
   //
   // Setting these properties customizes the prompt.
   //

--- a/examples/color.js
+++ b/examples/color.js
@@ -1,5 +1,5 @@
 var prompt = require("../lib/prompt");
-var colors = require("colors/safe");
+var colors = require("@colors/colors/safe");
 //
 // Setting these properties customizes the prompt.
 //

--- a/lib/prompt.js
+++ b/lib/prompt.js
@@ -11,7 +11,7 @@ var events = require('events'),
     read = require('read'),
     validate = require('revalidator').validate,
     winston = require('winston'),
-    colors = require('colors/safe');
+    colors = require('@colors/colors/safe');
 
 //
 // Monkey-patch readline.Interface to work-around

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   ],
   "dependencies": {
     "async": "~0.9.0",
-    "colors": "1.4.0",
+    "@colors/colors": "1.5.0",
     "read": "1.0.x",
     "revalidator": "0.1.x",
     "winston": "2.x"


### PR DESCRIPTION
Per https://github.com/Marak/colors.js/issues/340, the colors package on which prompt depends has been migrated to @colors/colors. This PR performs the (very simple) migration. Thanks for your help with getting this into the next release, and let me know if you need any help with getting this fix out or other maintenance tasks.