### PR TITLE
Upgrade async to 3.2.3

### DIFF
--- a/lib/prompt.js
+++ b/lib/prompt.js
@@ -7,7 +7,8 @@
 
 var events = require('events'),
     readline = require('readline'),
-    async = require('async'),
+    eachSeries = require('async/eachSeries'),
+    rejectSeries = require('async/rejectSeries'),
     read = require('read'),
     validate = require('revalidator').validate,
     winston = require('winston'),
@@ -317,7 +318,7 @@ prompt._get = function (schema, callback) {
     //
     // Now, iterate and assemble the result.
     //
-    async.forEachSeries(iterator, function (branch, next) {
+    eachSeries(iterator, function (branch, next) {
       get(branch, function assembler(err, line) {
         if (err) {
           return next(err);
@@ -413,7 +414,7 @@ prompt.confirm = function (/* msg, options, callback */) {
     });
   }
 
-  async.rejectSeries(vars, confirm, function(err, result) {
+  rejectSeries(vars, confirm, function(err, result) {
     callback(null, result.length===0);
   });
 };

--- a/lib/prompt.js
+++ b/lib/prompt.js
@@ -409,11 +409,11 @@ prompt.confirm = function (/* msg, options, callback */) {
     }
 
     prompt.get([options], function (err, result) {
-      next(err ? false : yes.test(result[options.name]));
+      next(null, err ? false : yes.test(result[options.name]));
     });
   }
 
-  async.rejectSeries(vars, confirm, function(result) {
+  async.rejectSeries(vars, confirm, function(err, result) {
     callback(null, result.length===0);
   });
 };

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   ],
   "dependencies": {
     "@colors/colors": "1.5.0",
-    "async": "0.9.2",
+    "async": "1.0.0",
     "read": "1.0.x",
     "revalidator": "0.1.x",
     "winston": "2.x"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   ],
   "dependencies": {
     "@colors/colors": "1.5.0",
-    "async": "1.2.0",
+    "async": "1.3.0",
     "read": "1.0.x",
     "revalidator": "0.1.x",
     "winston": "2.x"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   ],
   "dependencies": {
     "@colors/colors": "1.5.0",
-    "async": "1.5.0",
+    "async": "1.5.2",
     "read": "1.0.x",
     "revalidator": "0.1.x",
     "winston": "2.x"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   ],
   "dependencies": {
     "@colors/colors": "1.5.0",
-    "async": "2.2.0",
+    "async": "2.3.0",
     "read": "1.0.x",
     "revalidator": "0.1.x",
     "winston": "2.x"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   ],
   "dependencies": {
     "@colors/colors": "1.5.0",
-    "async": "2.5.0",
+    "async": "2.6.1",
     "read": "1.0.x",
     "revalidator": "0.1.x",
     "winston": "2.x"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   ],
   "dependencies": {
     "@colors/colors": "1.5.0",
-    "async": "2.6.2",
+    "async": "2.6.3",
     "read": "1.0.x",
     "revalidator": "0.1.x",
     "winston": "2.x"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   ],
   "dependencies": {
     "@colors/colors": "1.5.0",
-    "async": "2.4.1",
+    "async": "2.5.0",
     "read": "1.0.x",
     "revalidator": "0.1.x",
     "winston": "2.x"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   ],
   "dependencies": {
     "@colors/colors": "1.5.0",
-    "async": "2.6.3",
+    "async": "3.0.0",
     "read": "1.0.x",
     "revalidator": "0.1.x",
     "winston": "2.x"
@@ -35,6 +35,6 @@
   },
   "license": "MIT",
   "engines": {
-    "node": ">= 0.6.6"
+    "node": ">= 6.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   ],
   "dependencies": {
     "@colors/colors": "1.5.0",
-    "async": "3.0.0",
+    "async": "3.1.1",
     "read": "1.0.x",
     "revalidator": "0.1.x",
     "winston": "2.x"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   ],
   "dependencies": {
     "@colors/colors": "1.5.0",
-    "async": "3.1.1",
+    "async": "3.2.3",
     "read": "1.0.x",
     "revalidator": "0.1.x",
     "winston": "2.x"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   ],
   "dependencies": {
     "@colors/colors": "1.5.0",
-    "async": "2.3.0",
+    "async": "2.4.1",
     "read": "1.0.x",
     "revalidator": "0.1.x",
     "winston": "2.x"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   ],
   "dependencies": {
     "@colors/colors": "1.5.0",
-    "async": "1.4.0",
+    "async": "1.5.0",
     "read": "1.0.x",
     "revalidator": "0.1.x",
     "winston": "2.x"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   ],
   "dependencies": {
     "@colors/colors": "1.5.0",
-    "async": "1.1.0",
+    "async": "1.2.0",
     "read": "1.0.x",
     "revalidator": "0.1.x",
     "winston": "2.x"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   ],
   "dependencies": {
     "@colors/colors": "1.5.0",
-    "async": "2.1.5",
+    "async": "2.2.0",
     "read": "1.0.x",
     "revalidator": "0.1.x",
     "winston": "2.x"

--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
     "validation"
   ],
   "dependencies": {
-    "async": "~0.9.0",
     "@colors/colors": "1.5.0",
+    "async": "0.9.2",
     "read": "1.0.x",
     "revalidator": "0.1.x",
     "winston": "2.x"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   ],
   "dependencies": {
     "@colors/colors": "1.5.0",
-    "async": "1.3.0",
+    "async": "1.4.0",
     "read": "1.0.x",
     "revalidator": "0.1.x",
     "winston": "2.x"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   ],
   "dependencies": {
     "@colors/colors": "1.5.0",
-    "async": "2.6.1",
+    "async": "2.6.2",
     "read": "1.0.x",
     "revalidator": "0.1.x",
     "winston": "2.x"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   ],
   "dependencies": {
     "@colors/colors": "1.5.0",
-    "async": "2.0.0",
+    "async": "2.1.5",
     "read": "1.0.x",
     "revalidator": "0.1.x",
     "winston": "2.x"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   ],
   "dependencies": {
     "@colors/colors": "1.5.0",
-    "async": "1.5.2",
+    "async": "2.0.0",
     "read": "1.0.x",
     "revalidator": "0.1.x",
     "winston": "2.x"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   ],
   "dependencies": {
     "@colors/colors": "1.5.0",
-    "async": "1.0.0",
+    "async": "1.1.0",
     "read": "1.0.x",
     "revalidator": "0.1.x",
     "winston": "2.x"


### PR DESCRIPTION
This addresses a vulnerability in all `async` versions below 3.2.2 as advised on the [snyk page](https://security.snyk.io/vuln/SNYK-JS-ASYNC-2441827).

Unfortunately, upgrading to `async@3.0.0` and above breaks compatibility for node < v6.0.0 and this PR is technically a breaking change.