### PR TITLE
fix: prompt word duplicated

### DIFF
--- a/README.md
+++ b/README.md
@@ -434,7 +434,7 @@ prompt.stop();
 
 ## Disabling prompt's built-in SIGINT handling
 
-By default, prompt prompt binds a process-killing event handler to the SIGINT event (CTRL+C). This allows easily exiting from prompts, but can prevent an app from executing other event handlers when an interrupt is received. In order to override this default behavior, pass a `{noHandleSIGINT: true}` option into `prompt.start`.
+By default, prompt binds a process-killing event handler to the SIGINT event (CTRL+C). This allows easily exiting from prompts, but can prevent an app from executing other event handlers when an interrupt is received. In order to override this default behavior, pass a `{noHandleSIGINT: true}` option into `prompt.start`.
 
 ``` js
   //


### PR DESCRIPTION
prompt word duplicated